### PR TITLE
Update CI/Actions runners

### DIFF
--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -4,19 +4,19 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.9]
+        python-version: [3.12]
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -21,14 +21,14 @@ on:
 jobs:
   build-pypi-distribs:
     name: Build and publish library to PyPI
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: 3.12
 
       - name: Install pypa/build
         run: python -m pip install build --user
@@ -37,7 +37,7 @@ jobs:
         run: python -m build --sdist --wheel --outdir dist/
 
       - name: Upload built archives
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pypi_archives
           path: dist/*
@@ -47,17 +47,17 @@ jobs:
     name: Create GH release
     needs:
       - build-pypi-distribs
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Download built archives
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: pypi_archives
           path: dist
 
       - name: Create GH release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           draft: true
           files: dist/*
@@ -67,11 +67,11 @@ jobs:
     name: Create PyPI release
     needs:
       - create-gh-release
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Download built archives
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: pypi_archives
           path: dist

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,17 +9,17 @@ jobs:
 
     - template: etc/ci/azure-posix.yml
       parameters:
-          job_name: ubuntu20_cpython
-          image_name: ubuntu-20.04
-          python_versions: ['3.8', '3.9', '3.10', '3.11', '3.12']
+          job_name: ubuntu22_cpython
+          image_name: ubuntu-22.04
+          python_versions: ['3.9', '3.10', '3.11', '3.12', '3.13']
           test_suites:
               all: venv/bin/pytest -n 2 -vvs
 
     - template: etc/ci/azure-posix.yml
       parameters:
-          job_name: ubuntu22_cpython
-          image_name: ubuntu-22.04
-          python_versions: ['3.8', '3.9', '3.10', '3.11', '3.12']
+          job_name: ubuntu24_cpython
+          image_name: ubuntu-24.04
+          python_versions: ['3.9', '3.10', '3.11', '3.12', '3.13']
           test_suites:
               all: venv/bin/pytest -n 2 -vvs
 
@@ -27,7 +27,7 @@ jobs:
       parameters:
           job_name: macos13_cpython
           image_name: macOS-13
-          python_versions: ['3.8', '3.9', '3.10', '3.11', '3.12']
+          python_versions: ['3.9', '3.10', '3.11', '3.12', '3.13']
           test_suites:
               all: venv/bin/pytest -n 2 -vvs
 
@@ -35,7 +35,7 @@ jobs:
       parameters:
           job_name: macos14_cpython_arm64
           image_name: macOS-14
-          python_versions: ['3.8', '3.9', '3.10', '3.11', '3.12']
+          python_versions: ['3.9', '3.10', '3.11', '3.12', '3.13']
           test_suites:
               all: venv/bin/pytest -n 2 -vvs
 
@@ -43,7 +43,7 @@ jobs:
       parameters:
           job_name: macos14_cpython
           image_name: macOS-14-large
-          python_versions: ['3.8', '3.8', '3.9', '3.10', '3.12']
+          python_versions: ['3.9', '3.10', '3.11', '3.12', '3.13']
           test_suites:
               all: venv/bin/pytest -n 2 -vvs
 
@@ -51,7 +51,7 @@ jobs:
       parameters:
           job_name: win2019_cpython
           image_name: windows-2019
-          python_versions: ['3.8', '3.9', '3.10', '3.11', '3.12']
+          python_versions: ['3.9', '3.10', '3.11', '3.12', '3.13']
           test_suites:
               all: venv\Scripts\pytest -n 2 -vvs
 
@@ -59,6 +59,6 @@ jobs:
       parameters:
           job_name: win2022_cpython
           image_name: windows-2022
-          python_versions: ['3.8', '3.9', '3.10', '3.11', '3.12']
+          python_versions: ['3.9', '3.10', '3.11', '3.12', '3.13']
           test_suites:
               all: venv\Scripts\pytest -n 2 -vvs


### PR DESCRIPTION
Github Actions updates:

* `actions/upload-artifact@v3` -> `actions/upload-artifact@v4` and `actions/download-artifact@v3` -> `actions/download-artifact@v4` [Migration guide](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md)
* `actions/setup-python@v4` -> `actions/setup-python@v5` (node version update)
* `actions/checkout@v3` -> `actions/checkout@v4` (node version update)
* `softprops/action-gh-release@v1` -> `softprops/action-gh-release@v2` (node version update) 

Runners updates:
* Drop `macos-12`
* Use `ubuntu-24.04` and `python3.12` if only one CI run
